### PR TITLE
changed to use option to prevent dancer session engine from sending cookies

### DIFF
--- a/lib/Plack/Middleware/Debug/Dancer/Session.pm
+++ b/lib/Plack/Middleware/Debug/Dancer/Session.pm
@@ -11,7 +11,7 @@ sub run {
     my ( $self, $env, $panel ) = @_;
 
     return sub {
-        my $session = Dancer::Session->get();
+        my $session = Dancer::Session->get(no_update => 1);
         my @settings = map { $_ => $session->{$_}} keys %$session;
         $panel->title('Dancer::Session');
         $panel->nav_subtitle("Dancer::Session");


### PR DESCRIPTION
The current version generates a plack error (duplicate cookie sent-ish message) since the dancer session code will automatically update a session on read and send the cookie.

I've added a patch to dancer (accepted in last release) to allow reads of session data w/out it updating the session. This pull request has the code update to plack middleware to use the new option.
